### PR TITLE
Add dateFormat tests and npm test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "2.6.0",
   "private": true,
   "scripts": {
-    "start": "node client-app"
+    "start": "node client-app",
+    "test": "node tests/dateformat.test.js"
   },
   "dependencies": {
     "async": "^3.2.4",

--- a/tests/dateformat.test.js
+++ b/tests/dateformat.test.js
@@ -1,0 +1,14 @@
+const assert = require('assert');
+const dateFormat = require('../lib/dateformat');
+
+assert.strictEqual(
+  dateFormat('2023-01-02T03:04:05Z', 'isoDate'),
+  '2023-01-02'
+);
+
+assert.strictEqual(
+  dateFormat('2023-01-02T03:04:05Z', 'isoUtcDateTime'),
+  '2023-01-02T03:04:05Z'
+);
+
+console.log('All tests passed');


### PR DESCRIPTION
## Summary
- add simple dateFormat test using Node's `assert`
- run the test via npm script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850c6ed53d4832e9874ce1a5cde851a