### PR TITLE
Fix accidental global in for-in loop

### DIFF
--- a/public/js/client-options.js
+++ b/public/js/client-options.js
@@ -88,7 +88,7 @@ var clientOptions = {
     },
     'buildQueryString' : function() {
         var qs = '';
-        for (name in clientOptions.options) {
+        for (var name in clientOptions.options) {
             var option = this.get(name);
             qs += (qs == '' ? '' : '&');
             //console.log(option);


### PR DESCRIPTION
## Summary
- prevent accidental global by declaring loop variable in `client-options`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850cd94d294832ea00cc1519c08b9ce