### PR TITLE
Fix charmatch assignment scope

### DIFF
--- a/routes/socket.js
+++ b/routes/socket.js
@@ -195,7 +195,8 @@ exports.connection = function ( socket ) {
 
     if ( command.indexOf('connect ') != -1 || command.indexOf('co ') != -1 ) {
       // possibly id the character being connected
-      if (charmatch = command.match( /(connect|co) (\w+) \w/)) {
+      var charmatch = command.match( /(connect|co) (\w+) \w/ );
+      if ( charmatch ) {
         var charname = charmatch[charmatch.length-1];
         // log some useful information for troubleshooting
         logUser( socket, 'USR', [ charname ] );


### PR DESCRIPTION
## Summary
- scope `charmatch` properly when matching the connect command

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6852be6e44ec832ea745e97c04ef76a0