### PR TITLE
Add architecture overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ Below are also instructions for doing it on Ubuntu.
 * Local Editing of files / properties / verbs. If you're connected to a MOO and you set @edit-options +local you should be able to edit verbs in the local edtior. The game you're using can actually ship any text to the local editor and a command that it should execute upon 'save'. Double click the screen to pause / unpause the scroll
 * Object Number & Corified Reference selection on click (for easy copy and paste)
 
+## Architecture
+For a detailed overview of how the browser, Node.js server and game server interact, see [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
+
+
 ## Passthrough Identification of Player IP/Hostname
 Running a webclient can be fun, but you may also be concerned about providing one that does not identify the player who is using it by their IP, since the IP that would show as connecting to the game would be the IP of the webclient server. That can be handled by the game. If you game sends the text: '#$# dome-client-user' the webclient running for the player will send @dome-client-user <IP or hostname>.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,48 @@
+# System Architecture
+
+This document provides an overview of how the web client interacts with the game and describes the lifecycle of the socket connections.
+
+## Overview
+The application is a Node.js server that serves static assets and bridges WebSocket connections from browsers to a text-based game running over a standard TCP connection.
+
+- **Browser**: Loads the client UI from the Node server and uses `socket.io` to connect back.
+- **Node server** (`client-app.js`): Hosts HTTP/HTTPS endpoints using Express and manages Socket.IO connections.
+- **Game server**: A MUD/MOO server accepting plain TCP connections.
+
+The server reads configuration from environment variables (see `.env-example`) such as `SOCKET_URL`, `SOCKET_URL_SSL`, `GAME_HOST` and `GAME_PORT`.
+
+## Component Diagram
+```mermaid
+graph TD
+  Browser -- HTTP/HTTPS --> NodeServer
+  Browser -- "WebSocket (socket.io)" --> NodeServer
+  NodeServer -- "TCP (telnet)" --> GameServer
+```
+
+## Socket Lifecycle
+The front‑end JavaScript builds a socket using `io.connect()` (see `public/js/client-src/g-socket-lifecycle.js`). On the server side a matching Socket.IO handler in `routes/socket.js` opens a TCP connection to the game.
+
+```mermaid
+sequenceDiagram
+  participant B as Browser
+  participant N as Node.js App
+  participant M as Game Server
+
+  B->>N: io.connect()
+  N->>M: net.connect()
+  M-->>N: connect
+  N->>B: "connected"
+  loop User input
+    B->>N: "input"
+    N->>M: command
+    M-->>N: data
+    N-->>B: data
+  end
+  M-->>N: end/error
+  N->>B: "disconnected"/"error"
+  B->>N: disconnect
+  N->>M: "@quit"
+```
+
+The browser may attempt to reconnect automatically if the connection drops. When the user closes the page or the game ends, `@quit` is sent and both sockets are closed.
+


### PR DESCRIPTION
## Summary
- document full system architecture and socket lifecycle
- link the new documentation from README

## Testing
- `npm test` *(fails: Cannot find module 'colors')*

------
https://chatgpt.com/codex/tasks/task_e_68648b2a24e4832e98378dbd175c8e81